### PR TITLE
fix typespec for credentials inside request

### DIFF
--- a/lib/request.ex
+++ b/lib/request.ex
@@ -6,5 +6,5 @@ defmodule RsTwitter.Request do
   defstruct endpoint: nil, method: :get, parameters: %{}, credentials: nil
 
   @type t :: %RsTwitter.Request{endpoint: String.t(), method: atom, parameters: map(),
-    credentials: RsTwitter.Credentials | nil}
+    credentials: RsTwitter.Credentials.t() | nil}
 end


### PR DESCRIPTION
Fixes this Dialyzer warning:

```elixir
The function call will not succeed.

RsTwitter.request(%RsTwitter.Request{
  :credentials => %RsTwitter.Credentials{_ => _},
  :endpoint => <<_::208>>,
  :method => :get,
  :parameters => %{}
})

breaks the contract
(RsTwitter.Request.t()) :: {:ok, RsTwitter.Response.t()} | {:error, atom()}
```